### PR TITLE
Speeds up the cursor greatly by not drawing every motion event

### DIFF
--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -545,6 +545,16 @@ void LocalEvent::HandleKeyboardEvent(SDL_KeyboardEvent &event)
 
 void LocalEvent::HandleMouseMotionEvent(const SDL_MouseMotionEvent &motion)
 {
+    LocalEvent &le = Get();
+    // redraw cursor
+    if (le.redraw_cursor_func)
+    {
+        if (le.modes & MOUSE_OFFSET)
+            (*(le.redraw_cursor_func))(motion.x + le.mouse_st.x, motion.y + le.mouse_st.y);
+        else
+            (*(le.redraw_cursor_func))(motion.x, motion.y);
+    }
+
     mouse_state = motion.state;
     SetModes(MOUSE_MOTION);
     mouse_cu.x = motion.x;
@@ -842,19 +852,6 @@ void LocalEvent::SetGlobalFilterKeysEvents(void (*pf)(int, int))
 int LocalEvent::GlobalFilterEvents(const SDL_Event *event)
 {
     LocalEvent &le = Get();
-
-    // motion
-    if ((le.modes & GLOBAL_FILTER) && SDL_MOUSEMOTION == event->type)
-    {
-        // redraw cursor
-        if (le.redraw_cursor_func)
-        {
-            if (le.modes & MOUSE_OFFSET)
-                (*(le.redraw_cursor_func))(event->motion.x + le.mouse_st.x, event->motion.y + le.mouse_st.y);
-            else
-                (*(le.redraw_cursor_func))(event->motion.x, event->motion.y);
-        }
-    }
 
     // key
     if ((le.modes & GLOBAL_FILTER) && SDL_KEYDOWN == event->type)


### PR DESCRIPTION
I think SDL on my system was generating a very high rate of mouse motion events each of which was being drawn (and additional mouse events were getting generated during the draw) to the point of creating a large delay #2 

It may be that the localevent changes from bd180eab3de117f1cd9496ed4d11a24ca6022f80 aren't necessary if this is a good approach- I haven't tested much, just clicked around the opening menus some.