### PR TITLE
battle_interface: lighting bolt segfault. Stop passing negative lower value for Rand(uint, uint)

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3493,8 +3493,8 @@ namespace
         for (int i = 1; i<steps; i++)
         {
             Point interpolated = pointLerp(start, endPoint, pos);
-            interpolated.x += Rand::Get(-20, 20);
-            interpolated.y += Rand::Get(-20, 20);
+            interpolated.x += (20 - Rand::Get(0, 40));
+            interpolated.y += (20 - Rand::Get(0, 40));
             drawPoints.push_back(interpolated);
             pos += floatPart;
         }


### PR DESCRIPTION
I presume, that was the root cause for the bug mentioned on the [issue #12].

Rand::Get(-20, 20) should have made compiler complain, because first argument is invalid. Oh well, it was not. So, here we go, passing proper non-negative value as a first argument and keeping the functionality.