### PR TITLE
Lower the required CMake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.5)
 project(fheroes2)
 
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
I'm almost sure that it could be lowered event more. But at the moment I could only test it on 3.5.1 (stock Ubuntu 16.04 and Debian Buster package).

Following the issue #10 